### PR TITLE
Remove '-' from list of unwanted symbols for a BibTeX field's name

### DIFF
--- a/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTabViewModel.java
+++ b/src/main/java/org/jabref/gui/preferences/entryeditor/EntryEditorTabViewModel.java
@@ -13,7 +13,6 @@ import org.jabref.gui.DialogService;
 import org.jabref.gui.entryeditor.EntryEditorPreferences;
 import org.jabref.gui.preferences.GuiPreferences;
 import org.jabref.gui.preferences.PreferenceTabViewModel;
-import org.jabref.logic.citationkeypattern.CitationKeyGenerator;
 import org.jabref.logic.importer.fetcher.MrDlibPreferences;
 import org.jabref.logic.l10n.Localization;
 import org.jabref.model.entry.field.Field;
@@ -121,16 +120,11 @@ public class EntryEditorTabViewModel implements PreferenceTabViewModel {
                 return;
             }
 
-            // Use literal string of unwanted characters specified below as opposed to exporting characters
-            // from preferences because the list of allowable characters in this particular differs
-            // i.e. ';' character is allowed in this window, but it's on the list of unwanted chars in preferences
-            String unwantedChars = "#{}()~,^&-\"'`ʹ\\";
-            String testString = CitationKeyGenerator.cleanKey(parts[1], unwantedChars);
-            if (!testString.equals(parts[1])) {
+            if (! FieldFactory.isValidFieldName(parts[1])) {
                 dialogService.showInformationDialogAndWait(
                         Localization.lang("Error"),
                         Localization.lang("Field names are not allowed to contain white spaces or certain characters (%0).",
-                                "# { } ( ) ~ , ^ & - \" ' ` ʹ \\"));
+                                String.join(" ", FieldFactory.UNWANTED_CHARS.split(""))));
                 return;
             }
 

--- a/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
+++ b/src/main/java/org/jabref/logic/importer/fileformat/BibtexParser.java
@@ -717,7 +717,8 @@ public class BibtexParser implements Parser {
     }
 
     private void parseField(BibEntry entry) throws IOException {
-        Field field = FieldFactory.parseField(parseTextToken().toLowerCase(Locale.ROOT));
+        String fieldName = parseTextToken().toLowerCase(Locale.ROOT);
+        Field field = FieldFactory.parseField(fieldName);
 
         skipWhitespace();
         consume('=');

--- a/src/main/java/org/jabref/model/entry/field/FieldFactory.java
+++ b/src/main/java/org/jabref/model/entry/field/FieldFactory.java
@@ -29,6 +29,8 @@ public class FieldFactory {
     private static final String FIELD_OR_SEPARATOR = "/";
     private static final String DELIMITER = ";";
 
+    public static final String UNWANTED_CHARS = "#{}()~,^&\"'`ʹ\\";
+
     public static String serializeOrFields(Field... fields) {
         return serializeOrFields(new OrFields(fields));
     }
@@ -108,6 +110,16 @@ public class FieldFactory {
                      })
                      .collect(Collectors.joining(DELIMITER));
     }
+
+    public static boolean isValidFieldName(String fieldName) {
+        for (int symbol : UNWANTED_CHARS.toCharArray()) {
+            if (fieldName.indexOf(symbol) != -1) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 
     /**
      * Type T is an entry type and is used to direct the mapping to the Java field class.

--- a/src/main/java/org/jabref/model/entry/field/FieldFactory.java
+++ b/src/main/java/org/jabref/model/entry/field/FieldFactory.java
@@ -1,7 +1,7 @@
 package org.jabref.model.entry.field;
 
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -42,7 +42,7 @@ public class FieldFactory {
     /**
      * ASCII encoder used to validate the name of a field.
      */
-    private static CharsetEncoder ASCII_ENCODER = Charset.forName("US-ASCII").newEncoder();
+    private static final CharsetEncoder ASCII_ENCODER = StandardCharsets.US_ASCII.newEncoder();
 
     public static String serializeOrFields(Field... fields) {
         return serializeOrFields(new OrFields(fields));

--- a/src/main/java/org/jabref/model/entry/field/FieldFactory.java
+++ b/src/main/java/org/jabref/model/entry/field/FieldFactory.java
@@ -1,5 +1,7 @@
 package org.jabref.model.entry.field;
 
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -29,7 +31,18 @@ public class FieldFactory {
     private static final String FIELD_OR_SEPARATOR = "/";
     private static final String DELIMITER = ";";
 
-    public static final String UNWANTED_CHARS = "#{}()~,^&\"'`ʹ\\";
+    /**
+     * There are some ASCII symbols that, although not invalid from BibTeX
+     * point of view, are troublesome when processing the data using LaTeX.
+     * Thus, considering some references on Stackoverflow (https://tex.stackexchange.com/a/408548),
+     * I created a new list of unwanted symbols.
+     */
+    public static final String UNWANTED_CHARS = " ,{}()\"'%#~\\";
+
+    /**
+     * ASCII encoder used to validate the name of a field.
+     */
+    private static CharsetEncoder ASCII_ENCODER = Charset.forName("US-ASCII").newEncoder();
 
     public static String serializeOrFields(Field... fields) {
         return serializeOrFields(new OrFields(fields));
@@ -111,7 +124,20 @@ public class FieldFactory {
                      .collect(Collectors.joining(DELIMITER));
     }
 
+    /**
+     * Check if the field name is a reasonable value.
+     *
+     * We often consider that the field name should only contain ASCII symbols.
+     * Moreover, there are some symbols that, although not invalid from BibTeX
+     * point of view, are troublesome when processing the data using LaTeX.
+     *
+     * @param fieldName Name of the field to be verified.
+     * @return True if the name is valid, false otherwise.
+     */
     public static boolean isValidFieldName(String fieldName) {
+        if (! ASCII_ENCODER.canEncode(fieldName)) {
+            return false;
+        }
         for (int symbol : UNWANTED_CHARS.toCharArray()) {
             if (fieldName.indexOf(symbol) != -1) {
                 return false;

--- a/src/test/java/org/jabref/model/entry/field/FieldFactoryTest.java
+++ b/src/test/java/org/jabref/model/entry/field/FieldFactoryTest.java
@@ -21,6 +21,7 @@ class FieldFactoryTest {
         assertTrue(FieldFactory.isValidFieldName("authors"));
         assertTrue(FieldFactory.isValidFieldName("comment-"));
         assertTrue(FieldFactory.isValidFieldName("__internal"));
+        assertTrue(FieldFactory.isValidFieldName("field_name_without_spaces"));
     }
 
     @Test
@@ -28,6 +29,8 @@ class FieldFactoryTest {
         assertFalse(FieldFactory.isValidFieldName("authors{}"));
         assertFalse(FieldFactory.isValidFieldName("comment#"));
         assertFalse(FieldFactory.isValidFieldName("'internal"));
+        assertFalse(FieldFactory.isValidFieldName("field name with spaces"));
+        assertFalse(FieldFactory.isValidFieldName("notASCIIáéíóú"));
     }
 
     @Test

--- a/src/test/java/org/jabref/model/entry/field/FieldFactoryTest.java
+++ b/src/test/java/org/jabref/model/entry/field/FieldFactoryTest.java
@@ -10,9 +10,26 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FieldFactoryTest {
+
+    @Test
+    void isValidFieldName() {
+        assertTrue(FieldFactory.isValidFieldName("authors"));
+        assertTrue(FieldFactory.isValidFieldName("comment-"));
+        assertTrue(FieldFactory.isValidFieldName("__internal"));
+    }
+
+    @Test
+    void isInvalidFieldName() {
+        assertFalse(FieldFactory.isValidFieldName("authors{}"));
+        assertFalse(FieldFactory.isValidFieldName("comment#"));
+        assertFalse(FieldFactory.isValidFieldName("'internal"));
+    }
+
     @Test
     void orFieldsTwoTerms() {
         assertEquals("Aaa/Bbb", FieldFactory.serializeOrFields(new UnknownField("aaa"), new UnknownField("bbb")));


### PR DESCRIPTION
Remove '-' from list of unwanted symbols for a BibTeX field's name. Even JabRef uses '-' as symbol for a field's name (eg., "comment-").

Closes #26.

### Mandatory checks

<!-- 
- Go through the list below. Please don't remove any items.
- [x] done; [ ] not done / not applicable
-->

- [x] I own the copyright of the code submitted and I licence it under the [MIT license](https://github.com/JabRef/jabref/blob/main/LICENSE)
- [ ] Change in `CHANGELOG.md` described in a way that is understandable for the average user (if change is visible to the user)
- [X] Tests created for changes (if applicable)
- [X] Manually tested changed features in running JabRef (always required)
- [ ] Screenshots added in PR description (for UI changes)
- [ ] [Checked developer's documentation](https://devdocs.jabref.org/): Is the information available and up to date? If not, I outlined it in this pull request.
- [ ] [Checked documentation](https://docs.jabref.org/): Is the information available and up to date? If not, I created an issue at <https://github.com/JabRef/user-documentation/issues> or, even better, I submitted a pull request to the documentation repository.
